### PR TITLE
Fix lyrics handling

### DIFF
--- a/vibin/base.py
+++ b/vibin/base.py
@@ -620,7 +620,7 @@ class Vibin:
             Chunk.body.test(matches_regex, search_query))
         )
 
-        return results
+        return [result["media_id"] for result in results]
 
     # Expect data_format to be "json", "dat", or "png"
     # TODO: Investigate storing waveforms in a persistent cache/DB rather than

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -73,7 +73,7 @@ class LyricsChunk(BaseModel):
 
 
 class Lyrics(BaseModel):
-    media_id: str
+    media_id: Optional[str]
     chunks: list[LyricsChunk]
 
 

--- a/vibin/server/server.py
+++ b/vibin/server/server.py
@@ -373,7 +373,7 @@ def server_start(
 
         return {
             "query": lyrics_query.query,
-            "results": results,
+            "matches": results,
         }
 
     @vibin_app.get("/tracks/links")


### PR DESCRIPTION
* Return just media ids per match and not entire lyrics
* Allow for optional media id (e.g. lyrics for Airplay tracks)
* Return matches under `"matches"` key not `"results"`