### PR TITLE
Add support for proxying the media server's URLs via `/proxy`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /venv*
 /vibin.egg-info
 /vibin/_data
+/vibin/_webui
 
 __pycache__

--- a/vibin/cli/cli.py
+++ b/vibin/cli/cli.py
@@ -40,7 +40,7 @@ def cli():
     show_default=True,
 )
 @click.option(
-    "--port", "-i",
+    "--port", "-p",
     help="Port to listen on.",
     metavar="PORT",
     type=click.INT,
@@ -85,7 +85,22 @@ def cli():
     default=None,
     show_default=True,
 )
-def serve(host, port, streamer, media, no_media, discovery_timeout, vibinui):
+@click.option(
+    "--proxy-media-server", "-o",
+    help="Act as a proxy for the media server.",
+    is_flag=True,
+    default=False,
+)
+def serve(
+        host,
+        port,
+        streamer,
+        media,
+        no_media,
+        discovery_timeout,
+        vibinui,
+        proxy_media_server,
+):
     """
     Start the Vibin server.
 
@@ -135,6 +150,11 @@ def serve(host, port, streamer, media, no_media, discovery_timeout, vibinui):
 
      $ vibin serve --streamer MyStreamer --media MyMediaServer
     """
+    if proxy_media_server and no_media:
+        raise click.ClickException(
+            f"Cannot specify both --proxy-media-server and --no-media"
+        )
+
     with open(SERVER_FILE, "w") as server_file:
         server_file.write(f"http://{host}:{port}")
 
@@ -146,6 +166,7 @@ def serve(host, port, streamer, media, no_media, discovery_timeout, vibinui):
             media=False if no_media else media,
             discovery_timeout=discovery_timeout,
             vibinui=vibinui,
+            proxy_media_server=proxy_media_server,
         )
     except VibinError as e:
         raise click.ClickException(f"Could not start Vibin server: {e}")

--- a/vibin/mediasources/asset.py
+++ b/vibin/mediasources/asset.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from pathlib import Path
 import typing
+from urllib.parse import urlparse
 import upnpclient
 import xml.etree.ElementTree as ET
 
@@ -27,6 +28,17 @@ class Asset(MediaSource):
     @property
     def name(self):
         return self._device.friendly_name
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def url_prefix(self):
+        media_location = self.device.location
+        parsed_location = urlparse(media_location)
+
+        return f"{parsed_location.scheme}://{parsed_location.netloc}"
 
     @property
     def system_state(self):

--- a/vibin/mediasources/mediasource.py
+++ b/vibin/mediasources/mediasource.py
@@ -18,6 +18,16 @@ class MediaSource(metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def device(self):
+        pass
+
+    @property
+    @abstractmethod
+    def url_prefix(self):
+        pass
+
+    @property
+    @abstractmethod
     def system_state(self):
         pass
 

--- a/vibin/streamers/streamer.py
+++ b/vibin/streamers/streamer.py
@@ -39,6 +39,11 @@ class Streamer(metaclass=ABCMeta):
     ):
         pass
 
+    @property
+    @abstractmethod
+    def device(self):
+        pass
+
     @abstractmethod
     def register_media_source(self, media_source: MediaSource):
         pass


### PR DESCRIPTION
This feature is enabled with `vibin serve --proxy-media-server`.

The use case for proxying is when the UI will have access to the vibin server but won't have access to the media server device (perhaps because the UI is being accessed from another network).

Any payloads (REST or WebSocket) sent back to the UI which contain references to the media server (e.g. album art URLs) will instead have those references be replaced by `/proxy`. `/proxy` will then act as a reverse proxy to the media server's endpoints.

The downside to this is that more data is flowing through the vibin server, which will introduce additional load and potentially impact performance.