### PR TITLE
Remove async from non-async endpoints; exclude invalid from lyrics search

### DIFF
--- a/vibin/base.py
+++ b/vibin/base.py
@@ -717,7 +717,7 @@ class Vibin:
         return [
             result["media_id"]
             for result in results
-            if result["media_id"] is not None
+            if result["media_id"] is not None and result["is_valid"] is True
         ]
 
     # Expect data_format to be "json", "dat", or "png"

--- a/vibin/streamers/cxnv2.py
+++ b/vibin/streamers/cxnv2.py
@@ -29,6 +29,8 @@ from vibin.mediasources import MediaSource
 from vibin.streamers import SeekTarget, Streamer, TransportState
 from .. import utils
 
+# TODO: Consider using httpx instead of requests, and making some of these
+#   methods (particularly the ones that use SMOIP) async.
 
 # -----------------------------------------------------------------------------
 # NOTE: Media IDs only make sense when streaming from a local source. This


### PR DESCRIPTION


* Removing `async def` from the endpoints which aren't truly async will result in those endpoints being managed by FastAPI's thread pool; and they will no longer block the coroutine loop.
* Log a warning when an attempt to proxy a media server url times out.
* When performing a lyrics search, don't return matches for lyrics which have been marked as invalid.