### PR TITLE
Make TinyDB writes thread safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "rich",
         "starlette",
         "tinydb",
+        "tinyrecord",
         "untangle",
         "upnpclient",
         "uvicorn[standard]",


### PR DESCRIPTION
Uses `transaction` (a thread-locking context manager) from the `tinyrecord` package.