### PR TITLE
Reorder endpoints to avoid subroutes being misinterpreted as resource ids

### DIFF
--- a/vibin/server/routers/stored_playlists.py
+++ b/vibin/server/routers/stored_playlists.py
@@ -19,6 +19,21 @@ def playlists() -> list[StoredPlaylist]:
     return get_vibin_instance().playlists()
 
 
+@stored_playlists_router.post(
+    "/current/store",
+    summary="Store the Streamer's active Playlist as a new Stored Playlist",
+    tags=["Stored Playlists"],
+)
+def playlists_current_store(
+    name: str | None = None, replace: bool | None = True
+) -> StoredPlaylist:
+    metadata = {"name": name} if name else None
+
+    return get_vibin_instance().store_active_playlist(
+        metadata=metadata, replace=replace
+    )
+
+
 @stored_playlists_router.get(
     "/{playlist_id}",
     summary="Retrieve details on a single Stored Playlist",
@@ -87,18 +102,3 @@ def playlists_id_make_current(playlist_id: str) -> StoredPlaylist:
         )
     except VibinDeviceError as e:
         raise HTTPException(status_code=503, detail=f"Downstream device error: {e}")
-
-
-@stored_playlists_router.post(
-    "/current/store",
-    summary="Store the Streamer's active Playlist as a new Stored Playlist",
-    tags=["Stored Playlists"],
-)
-def playlists_current_store(
-    name: str | None = None, replace: bool | None = True
-) -> StoredPlaylist:
-    metadata = {"name": name} if name else None
-
-    return get_vibin_instance().store_active_playlist(
-        metadata=metadata, replace=replace
-    )

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -638,7 +638,7 @@ class StreamMagic(Streamer):
             # clients get the new track/album id information without having
             # to wait for a normal PlayState update.
             if send_update:
-                self._send_play_state_update()
+                self._send_currently_playing_update()
         except KeyError:
             # No streamed filename found in the playback details
             pass
@@ -671,6 +671,7 @@ class StreamMagic(Streamer):
             pass
 
         self._currently_playing.playlist.entries = playlist_entries
+        self._send_currently_playing_update()
 
     def _set_current_playlist_track_index(self, index: int):
         try:
@@ -801,10 +802,11 @@ class StreamMagic(Streamer):
     # -------------------------------------------------------------------------
     # Helpers to send messages back to Vibin
 
-    def _send_play_state_update(self):
-        self._on_update("PlayState", self.play_state)
-
+    def _send_currently_playing_update(self):
         self._on_update("CurrentlyPlaying", self.currently_playing)
+
+        # TODO: Remove PlayState send once no longer used by client
+        self._on_update("PlayState", self.play_state)
 
     def _send_transport_state_update(self):
         self._on_update("TransportState", self.transport_state)
@@ -1145,7 +1147,7 @@ class StreamMagic(Streamer):
             except (IndexError, KeyError) as e:
                 pass
 
-            self._send_play_state_update()
+            self._send_currently_playing_update()
             self._send_transport_state_update()
         elif update_dict["path"] == "/zone/play_state/position":
             # Transport playhead position -------------------------------------


### PR DESCRIPTION
Also ensure a `CurrentlyPlaying` update is sent when the active playlist is updated (e.g. when a stored playlist is activated).