### PR TITLE
Remove deprecated features

### DIFF
--- a/vibin/models.py
+++ b/vibin/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field
 import upnpclient
 
 from vibin.types import (
@@ -9,7 +9,6 @@ from vibin.types import (
     PlayStatus,
     PowerState,
     TransportAction,
-    TransportPlayStatus,
     TransportPosition,
     TransportRepeatState,
     TransportShuffleState,
@@ -234,43 +233,6 @@ class TransportPlayheadPositionPayload(BaseModel):
     """
 
     position: TransportPosition
-
-
-# TODO: Deprecate along with TransportPlayState
-class TransportPlayStateMetadata(BaseModel):
-    class_field: str | None = Field(alias="class")
-    source: str | None
-    name: str | None
-    playback_source: str | None
-    track_number: int | None
-    duration: int | None
-    album: str | None
-    artist: str | None
-    title: str | None
-    art_url: HttpUrl | None
-    sample_format: str | None
-    mqa: str | None
-    codec: str | None
-    lossless: bool | None
-    sample_rate: int | None
-    bit_depth: int | None
-    encoding: str | None
-    current_track_media_id: str | None
-    current_album_media_id: str | None
-
-
-# TODO: Remove once confirmed it's not in use (replaced by TransportState)
-class TransportPlayState(BaseModel):
-    state: TransportPlayStatus | None
-    position: int | None
-    # TODO: Consider renaming "queue_*" to "active_playlist_*", or just remove
-    #   since they can be determined from the active playlist
-    queue_index: int | None
-    queue_length: int | None
-    queue_id: int | None
-    mode_repeat: TransportRepeatState | None
-    mode_shuffle: TransportShuffleState | None
-    metadata: TransportPlayStateMetadata | None
 
 
 # Streamer's active playlist --------------------------------------------------

--- a/vibin/server/routers/transport.py
+++ b/vibin/server/routers/transport.py
@@ -2,12 +2,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
 from vibin import VibinError
-from vibin.models import (
-    TransportAction,
-    TransportPlayheadPositionPayload,
-    TransportPlayState,
-    TransportState,
-)
+from vibin.models import TransportPlayheadPositionPayload, TransportState
 from vibin.server.dependencies import get_vibin_instance
 from vibin.types import SeekTarget
 
@@ -143,23 +138,3 @@ def transport_play_media_id(media_id: str):
         get_vibin_instance().play_id(media_id)
     except VibinError as e:
         raise HTTPException(status_code=500, detail=str(e))
-
-
-@transport_router.get(
-    "/active_controls",
-    summary="Retrieve the list of currently-valid Transport controls",
-    tags=["Transport"],
-    deprecated=True,
-)
-def transport_active_controls() -> list[TransportAction]:
-    return get_vibin_instance().streamer.active_transport_controls
-
-
-@transport_router.get(
-    "/play_state",
-    summary="Retrieve the current play state",
-    tags=["Transport"],
-    deprecated=True,
-)
-def transport_play_state() -> TransportPlayState:
-    return get_vibin_instance().play_state

--- a/vibin/streamers/streamer.py
+++ b/vibin/streamers/streamer.py
@@ -13,7 +13,6 @@ from vibin.models import (
     StreamerDeviceDisplay,
     StreamerState,
     TransportAction,
-    TransportPlayState,
     TransportRepeatState,
     TransportShuffleState,
     TransportState,
@@ -320,15 +319,4 @@ class Streamer(metaclass=ABCMeta):
         """Invoked when a UPnP event has been received from a subscription
         managed by the Streamer.
         """
-        pass
-
-    # -------------------------------------------------------------------------
-    # TODO: Deprecate
-
-    @abstractmethod
-    def play_state(self) -> TransportPlayState:
-        pass
-
-    @abstractmethod
-    def vibin_vars(self):
         pass

--- a/vibin/types.py
+++ b/vibin/types.py
@@ -37,11 +37,8 @@ PlaylistModifyAction = Literal[
 
 # Message types sent to subscribed clients (over a WebSocket)
 UpdateMessageType = Literal[
-    "ActiveTransportControls",  # TODO: Deprecate
     "CurrentlyPlaying",
-    "DeviceDisplay",  # TODO: Deprecate
     "Favorites",
-    "PlayState",  # TODO: Deprecate
     "Position",
     "Presets",
     "StoredPlaylists",
@@ -92,18 +89,6 @@ TransportAction = Literal[
     "repeat",
     "seek",
     "shuffle",
-    "stop",
-]
-
-# TODO: Deprecate along with the TransportPlayState class
-TransportPlayStatus = Literal[
-    "buffering",
-    "connecting",
-    "no_signal",
-    "not_ready",
-    "pause",
-    "play",
-    "ready",
     "stop",
 ]
 


### PR DESCRIPTION
* Stop sending WebSocket messages: `PlayState`, `DeviceDisplay`, `ActiveTransportControls`
* Remove everything from `UPnPProperties` message payload except for top-level `streamer` and `media_server` properties
* Remove REST endpoints: `/transport/active_controls`, `/transport/play_state`
* Remove commented-out code