### PR TITLE
Update StreamMagic handling of navigator and WebSocket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ It is recommended to install and run `vibin` on an always-on device which mainta
 network connection at all times, such as a Raspberry Pi. It will still run on other devices (like a
 laptop), but may need to be restarted when the device comes out of sleep.
 
+`vibin` has been tested on:
+
+* Ubuntu 22.10 on a Raspberry Pi (Python 3.10)
+* MacOS 13.4 (Python 3.11)
+* Windows 11 (Python 3.11)
+
 ### Installing `vibin`
 
 `vibin` requires [Python 3.10] or higher.

--- a/vibin/streamers/streamer.py
+++ b/vibin/streamers/streamer.py
@@ -58,7 +58,6 @@ class Streamer(metaclass=ABCMeta):
     """
 
     model_name = "VibinStreamer"
-    navigator_name = "vibin"
 
     @abstractmethod
     def __init__(


### PR DESCRIPTION
* Use a unique navigator name per vibin instance. This should prevent one vibin's release of the navigator (on shutdown) from impacting other vibins running on the same network.
* Attempt to re-acquire a navigator when a `"BAD_NAVIGATOR"` response is received from the streamer.
* Attempt to re-connect to the streamer's WebSocket server when the server closes the connection (e.g. when the streamer reboots).