### PR TITLE
Improve artist determination in links manager

### DIFF
--- a/vibin/managers/links_manager.py
+++ b/vibin/managers/links_manager.py
@@ -169,9 +169,13 @@ class LinksManager:
                 # We have an array of artists, so look for AlbumArtist (others
                 # might be Composer, etc).
                 for upnp_artist in upnp_artist_info:
-                    if upnp_artist["@role"] == "AlbumArtist":
-                        artist = upnp_artist["#text"]
+                    if type(upnp_artist) == str:
+                        artist = upnp_artist
                         break
+                    else:
+                        if upnp_artist["@role"] == "AlbumArtist":
+                            artist = upnp_artist["#text"]
+                            break
         except KeyError:
             pass
 


### PR DESCRIPTION
Extends the artist-determination heuristic in `_artist_name_from_track_media_info()` to allow for another potential case. This logic is getting a little unwieldy and should be extracted at some point. It would also be good to dig into the UPnP specification to figure out what the real possibilities for artist name are, rather than going off of guesswork and seen cases.