### PR TITLE
Handle disconnected WebSocket client on send

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = ["media"]
 
 [project]
 name = "vibin"
-version = "1.0.1"
+version = "1.0.2"
 description = "The Vibin music server"
 authors = [
     { name = "Mike Joblin", email = "mjoblin@users.noreply.github.com" },


### PR DESCRIPTION
WebSocket clients sometimes go away without the server receiving a formal disconnect. This PR checks for `RuntimeError` on send, and removes the client from the active client list.