### PR TITLE
Add thread lock for DB reads

### DIFF
--- a/vibin/managers/links_manager.py
+++ b/vibin/managers/links_manager.py
@@ -12,6 +12,8 @@ from vibin.mediaservers import MediaServer
 from vibin.models import ExternalServiceLink, Links
 from vibin.types import MediaId
 
+from .shared import DB_READ_LOCK
+
 
 class LinksManager:
     """Links manager.
@@ -56,7 +58,9 @@ class LinksManager:
         # Check if links are already stored
         if media_id:
             StoredLinksQuery = Query()
-            stored_links = self._db.get(StoredLinksQuery.media_id == media_id)
+
+            with DB_READ_LOCK:
+                stored_links = self._db.get(StoredLinksQuery.media_id == media_id)
 
             if stored_links is not None:
                 links_data = Links(**stored_links)

--- a/vibin/managers/shared.py
+++ b/vibin/managers/shared.py
@@ -1,4 +1,20 @@
 import threading
 
 
+# Lock for use when reading from TinyDB.
+#
+# This is a somewhat dubious workaround for TinyDB issues. The DB sometimes gets
+# into a weird state where more than one instance of the DB's JSON data is
+# written to the db file on disk. This seems to be related to read/write races.
+# (TinyDB is itself not concurrency-aware).
+#
+# This relies on all the DB-read-related endpoint functions in FastAPI (which
+# call these manager methods) being "def" not "async def". FastAPI runs "def"
+# handlers in threads not coroutines; so this DB race workaround uses a
+# threading.Lock() to prevent multiple reads at once.
+#
+# Also, the "tinyrecord" package is already used for atomic writes to TinyDB.
+# This mix of "tinyrecord" for writes and a thread lock for reads seems dubious,
+# although it's an improvement so it'll do for now. Ultimately the persistence
+# solution should be reconsidered entirely.
 DB_READ_LOCK = threading.Lock()

--- a/vibin/managers/shared.py
+++ b/vibin/managers/shared.py
@@ -1,0 +1,4 @@
+import threading
+
+
+DB_READ_LOCK = threading.Lock()


### PR DESCRIPTION
This is a somewhat dubious workaround for TinyDB issues. The DB
sometimes gets into a weird state where more than one instance of the
DB's JSON data is written to the db file on disk. This seems to be
related to read/write races. (TinyDB is itself not concurrency-aware).

This PR relies on all the DB-read-related endpoint functions in FastAPI
being `def` not `async def`. FastAPI runs `def` handlers in threads not
coroutines; so this DB race workaround uses a `threading.Lock()` to
prevent multiple reads at once.

Also, the `tinyrecord` package was already used for atomic writes to
TinyDB. This mix of `tinyrecord` for writes and a thread lock for reads
seems dubious, although it's an improvement so it'll do for now.
Ultimately the persistence solution should be reconsidered entirely.