### PR TITLE
Have play and pause use toggle when available; add system power

### DIFF
--- a/vibin/base.py
+++ b/vibin/base.py
@@ -268,8 +268,24 @@ class Vibin:
 
     @property
     def system_state(self) -> SystemState:
-        """The current system state."""
+        """The current system device hardware state.
+
+        Returns details on the overall media system, the streamer, and (if
+        available) the media server and amplifier.
+
+        The overall system power will always be either "off" or "on". It's only
+        considered on if the streamer is on and the amplifier (if present) is
+        also on. A mixed on/off state for streamer/amp will have a system state
+        of "off".
+        """
+        system_power = "off" if self.streamer.power is None else self.streamer.power
+
+        if self.amplifier is not None:
+            if self.amplifier.power == "off" or self.amplifier.power is None:
+                system_power = "off"
+
         return SystemState(
+            power=system_power,
             streamer=self.streamer.device_state,
             media=self.media_server.device_state if self.media_server else None,
             amplifier=self.amplifier.device_state

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -149,6 +149,7 @@ class AmplifierState(UPnPDeviceState):
 class SystemState(BaseModel):
     """System hardware state."""
 
+    power: PowerState | None
     streamer: StreamerState
     media: MediaServerState | None
     amplifier: AmplifierState | None

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -350,15 +350,27 @@ class StreamMagic(Streamer):
         return self._transport_state
 
     def play(self):
-        self._av_transport.Play(InstanceID=self._instance_id, Speed="1")
+        if self._transport_state.play_state == "play":
+            return
+
+        if "toggle_playback" in self._transport_state.active_controls:
+            self.toggle_playback()
+        else:
+            self._av_transport.Play(InstanceID=self._instance_id, Speed="1")
+
+    def pause(self):
+        if self._transport_state.play_state == "pause":
+            return
+
+        if "toggle_playback" in self._transport_state.active_controls:
+            self.toggle_playback()
+        else:
+            self._av_transport.Pause(InstanceID=self._instance_id)
 
     def toggle_playback(self):
         requests.get(
             f"http://{self._device_hostname}/smoip/zone/play_control?action=toggle"
         )
-
-    def pause(self):
-        self._av_transport.Pause(InstanceID=self._instance_id)
 
     def stop(self):
         self._av_transport.Stop(InstanceID=self._instance_id)


### PR DESCRIPTION
* Play and pause will first attempt a streamer transport playback toggle if available in the active controls; otherwise they will fall back on conventional play and pause. This makes the play/pause API consistent while abstracting away the different pause/play behavior of various input sources.
* The System payload (REST and WebSocket) now includes a system power state, which will always be "on" or "off".