### PR TITLE
Improve CLI seek handling

### DIFF
--- a/vibin/__init__.py
+++ b/vibin/__init__.py
@@ -1,5 +1,6 @@
 from vibin.exceptions import (
     VibinDeviceError,
+    VibinInputError,
     VibinError,
     VibinNotFoundError,
     VibinMissingDependencyError,

--- a/vibin/exceptions.py
+++ b/vibin/exceptions.py
@@ -3,12 +3,20 @@ class VibinError(Exception):
 
 
 class VibinDeviceError(VibinError):
+    """A media hardware device issue."""
+    pass
+
+
+class VibinInputError(VibinError):
+    """Bad/unexpected user input."""
     pass
 
 
 class VibinNotFoundError(VibinError):
+    """Something was not found."""
     pass
 
 
 class VibinMissingDependencyError(VibinError):
+    """A required dependency is unavailable."""
     pass

--- a/vibin/server/routers/transport.py
+++ b/vibin/server/routers/transport.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 
-from vibin import VibinError
+from vibin import VibinInputError, VibinError
 from vibin.models import TransportPlayheadPositionPayload, TransportState
 from vibin.server.dependencies import get_vibin_instance
 from vibin.types import SeekTarget
@@ -138,6 +138,8 @@ def transport_shuffle() -> TransportState:
 def transport_seek(target: SeekTarget):
     try:
         get_vibin_instance().streamer.seek(target)
+    except VibinInputError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except VibinError as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -23,7 +23,7 @@ from upnpclient.marshal import marshal_value
 import websockets
 import xmltodict
 
-from vibin import utils, VibinDeviceError
+from vibin import utils, VibinDeviceError, VibinError, VibinInputError
 from vibin.logger import logger
 from vibin.mediaservers import MediaServer
 from vibin.models import (
@@ -376,6 +376,11 @@ class StreamMagic(Streamer):
         self._av_transport.Stop(InstanceID=self._instance_id)
 
     def seek(self, target: SeekTarget):
+        if "seek" not in self.active_transport_controls:
+            # TODO: Establish consistent way of handling "currently unavailable"
+            #   features.
+            raise VibinError("Seek currently unavailable")
+
         target_hmmss = None
 
         # TODO: Fix handling of float vs. int. All numbers come in as floats,
@@ -393,7 +398,7 @@ class StreamMagic(Streamer):
                 target_hmmss = utils.secs_to_hmmss(int(target))
         elif isinstance(target, str):
             if not utils.is_hmmss(target):
-                raise TypeError("Time must be in h:mm:ss format")
+                raise VibinInputError("Time must be in h:mm:ss format")
 
             target_hmmss = target
 


### PR DESCRIPTION
* Add `VibinInputError` exception class
* Return `404` on `VibinInputError`

Future: Establish consistent way of handling "currently unavailable" features; and consistent way to handle Vibin exception classes (e.g. HTTP response codes) in route handlers.