### PR TITLE
Improve determination of Album and Track Ids

### DIFF
--- a/vibin/mediaservers/asset.py
+++ b/vibin/mediaservers/asset.py
@@ -377,7 +377,7 @@ class Asset(MediaServer):
                 pass
 
         return Track(
-            id=item["id"],
+            id=item["id"].removesuffix(f"-{item['parentID']}"),
             parentId=item["parentID"],
             title=item.dc_title.cdata,
             creator=item.dc_creator.cdata,

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -697,6 +697,15 @@ class StreamMagic(Streamer):
             this_track_id = match.groups(0)[0]
             this_album_id = match.groups(0)[1]
 
+            if this_album_id == "0":
+                # An album id of "0" seems to mean that the album id is unknown,
+                # so strip it off.
+                this_album_id = None
+                this_track_id = this_track_id.removesuffix("-0")
+            else:
+                # We have a known album id, so strip it off of the track id.
+                this_track_id = this_track_id.replace(f"-{this_album_id}", "")
+
             return this_album_id, this_track_id
 
         return None, None


### PR DESCRIPTION
- Album Id is now stripped off of Track Id when creating Tracks.
- When determining Album and Track Ids from a filename, treat "0" Album Id as `None` and remove valid Album Id from Track Id.