### PR TITLE
Move from one TinyDB file to one file per table

### DIFF
--- a/vibin/managers/favorites_manager.py
+++ b/vibin/managers/favorites_manager.py
@@ -8,7 +8,7 @@ from vibin import VibinNotFoundError
 from vibin.mediaservers import MediaServer
 from vibin.models import Album, Favorite, FavoritesPayload, Track
 from vibin.types import FavoriteType, MediaId, UpdateMessageHandler
-from vibin.utils import DB_ACCESS_LOCK, requires_media_server
+from vibin.utils import DB_ACCESS_LOCK_FAVORITES, requires_media_server
 
 
 class FavoritesManager:
@@ -48,7 +48,7 @@ class FavoritesManager:
         # Check for existing favorite with this media_id
         FavoritesQuery = Query()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_FAVORITES:
             existing_favorite = self._db.get(FavoritesQuery.media_id == media_id)
 
         if existing_favorite:
@@ -74,7 +74,7 @@ class FavoritesManager:
             when_favorited=time.time(),
         )
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_FAVORITES:
             self._db.insert(favorite_data.dict())
 
         self._send_update()
@@ -86,13 +86,13 @@ class FavoritesManager:
 
         FavoritesQuery = Query()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_FAVORITES:
             favorite_to_delete = self._db.get(FavoritesQuery.media_id == media_id)
 
         if favorite_to_delete is None:
             raise VibinNotFoundError()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_FAVORITES:
             self._db.remove(doc_ids=[favorite_to_delete.doc_id])
 
         self._send_update()
@@ -112,7 +112,7 @@ class FavoritesManager:
 
         favorites = []
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_FAVORITES:
             for favorite in self._db.all():
                 if requested_types is None or favorite["type"] in requested_types:
                     try:

--- a/vibin/managers/links_manager.py
+++ b/vibin/managers/links_manager.py
@@ -10,7 +10,7 @@ from vibin.logger import logger
 from vibin.mediaservers import MediaServer
 from vibin.models import ExternalServiceLink, Links
 from vibin.types import MediaId
-from vibin.utils import DB_ACCESS_LOCK
+from vibin.utils import DB_ACCESS_LOCK_LINKS
 
 
 class LinksManager:
@@ -57,7 +57,7 @@ class LinksManager:
         if media_id:
             StoredLinksQuery = Query()
 
-            with DB_ACCESS_LOCK:
+            with DB_ACCESS_LOCK_LINKS:
                 stored_links = self._db.get(StoredLinksQuery.media_id == media_id)
 
             if stored_links is not None:
@@ -140,7 +140,7 @@ class LinksManager:
                 links=results,
             )
 
-            with DB_ACCESS_LOCK:
+            with DB_ACCESS_LOCK_LINKS:
                 self._db.insert(link_data.dict())
 
         return results

--- a/vibin/managers/playlists_manager.py
+++ b/vibin/managers/playlists_manager.py
@@ -15,7 +15,7 @@ from vibin.models import (
 )
 from vibin.streamers import Streamer
 from vibin.types import MediaId, PlaylistModifyAction, UpdateMessageHandler
-from vibin.utils import DB_ACCESS_LOCK, requires_media_server
+from vibin.utils import DB_ACCESS_LOCK_PLAYLISTS, requires_media_server
 
 
 class PlaylistsManager:
@@ -130,7 +130,7 @@ class PlaylistsManager:
     @property
     def stored_playlists(self) -> StoredPlaylists:
         """Details on all stored playlists."""
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_PLAYLISTS:
             playlists = StoredPlaylists(
                 status=self._stored_playlist_status,
                 playlists=[StoredPlaylist(**playlist) for playlist in self._db.all()],
@@ -142,7 +142,7 @@ class PlaylistsManager:
         """Details on a single stored playlist."""
         PlaylistQuery = Query()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_PLAYLISTS:
             playlist_dict = self._db.get(PlaylistQuery.id == playlist_id)
 
         if playlist_dict is None:
@@ -157,7 +157,7 @@ class PlaylistsManager:
 
         PlaylistQuery = Query()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_PLAYLISTS:
             playlist_dict = self._db.get(PlaylistQuery.id == stored_playlist_id)
 
         if playlist_dict is None:
@@ -214,7 +214,7 @@ class PlaylistsManager:
                 entry_ids=[entry.trackMediaId for entry in active_playlist.entries],
             )
 
-            with DB_ACCESS_LOCK:
+            with DB_ACCESS_LOCK_PLAYLISTS:
                 self._db.insert(playlist_data.dict())
 
             self._cached_stored_playlist = playlist_data
@@ -238,7 +238,7 @@ class PlaylistsManager:
             PlaylistQuery = Query()
 
             try:
-                with DB_ACCESS_LOCK:
+                with DB_ACCESS_LOCK_PLAYLISTS:
                     doc_id = self._db.update(
                         updates,
                         PlaylistQuery.id == self._stored_playlist_status.active_id,
@@ -273,7 +273,7 @@ class PlaylistsManager:
         """Delete a stored playlist."""
         PlaylistQuery = Query()
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_PLAYLISTS:
             playlist_to_delete = self._db.get(PlaylistQuery.id == playlist_id)
 
             if playlist_to_delete is None:
@@ -294,7 +294,7 @@ class PlaylistsManager:
         PlaylistQuery = Query()
 
         try:
-            with DB_ACCESS_LOCK:
+            with DB_ACCESS_LOCK_PLAYLISTS:
                 updated_ids = self._db.update(
                     {
                         "updated": now,
@@ -308,7 +308,7 @@ class PlaylistsManager:
 
             self._send_stored_playlists_update()
 
-            with DB_ACCESS_LOCK:
+            with DB_ACCESS_LOCK_PLAYLISTS:
                 playlist = StoredPlaylist(**self._db.get(doc_id=updated_ids[0]))
 
             return playlist
@@ -330,7 +330,7 @@ class PlaylistsManager:
             entry.trackMediaId for entry in streamer_playlist_entries
         ]
 
-        with DB_ACCESS_LOCK:
+        with DB_ACCESS_LOCK_PLAYLISTS:
             stored_playlists_as_dicts = [StoredPlaylist(**p) for p in self._db.all()]
 
         try:

--- a/vibin/types.py
+++ b/vibin/types.py
@@ -107,3 +107,11 @@ TransportShuffleState = Literal["off", "all"]
 # Int: Number of seconds into the track
 # Str: h:mm:ss into the track
 SeekTarget = float | int | str
+
+DatabaseName = Literal[
+    "favorites",
+    "links",
+    "lyrics",
+    "playlists",
+    "settings",
+]

--- a/vibin/utils.py
+++ b/vibin/utils.py
@@ -42,7 +42,11 @@ HMMSS_MATCH = re.compile("^\d+:\d{2}:\d{2}(\.\d+)?$")
 #
 # Ultimately the persistence solution should be reconsidered entirely, perhaps
 # preferring a solution which natively supports concurrent access.
-DB_ACCESS_LOCK = threading.Lock()
+DB_ACCESS_LOCK_FAVORITES = threading.Lock()
+DB_ACCESS_LOCK_LINKS = threading.Lock()
+DB_ACCESS_LOCK_LYRICS = threading.Lock()
+DB_ACCESS_LOCK_PLAYLISTS = threading.Lock()
+DB_ACCESS_LOCK_SETTINGS = threading.Lock()
 
 
 # =============================================================================


### PR DESCRIPTION
This initializes a separate TinyDB file per database table. It's possible to instead store all tables in one file, but that affects performance as the file size grows. The downside to multiple files is that we have a pretty sloppy collection of files, TinyDB instances, and DB locks. TinyDB should be replaced with another database solution TinyDB should be replaced with another database solution.