### PR TITLE
Further improve media Id determination

### DIFF
--- a/vibin/base.py
+++ b/vibin/base.py
@@ -182,6 +182,17 @@ class Vibin:
         else:
             logger.warning("Not using an amplifier; some features will be unavailable")
 
+        if self.media_server is not None:
+            # Fetching media counts here is useful for logging, but also ensures
+            # that the album and track details are hydrated by the media server
+            # before Vibin is allowed to continue initializing.
+            logger.info("Retrieving local media counts (might take a while)")
+
+            albums = self.media_server.albums
+            tracks = self.media_server.tracks
+
+            logger.info(f"Media server has {len(albums)} albums and {len(tracks)} tracks")
+
         # Initialize the managers for features like favorites, playlists, etc.
         self._favorites_manager = FavoritesManager(
             db=self._favorites_db,

--- a/vibin/mediaservers/mediaserver.py
+++ b/vibin/mediaservers/mediaserver.py
@@ -11,7 +11,7 @@ from vibin.models import (
     Track,
     UPnPServiceSubscriptions,
 )
-from vibin.types import MediaId, UpdateMessageHandler, UPnPProperties
+from vibin.types import MediaId, MediaType, UpdateMessageHandler, UPnPProperties
 
 
 # -----------------------------------------------------------------------------
@@ -161,6 +161,11 @@ class MediaServer(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def album(self, album_id: MediaId) -> Album:
+        """Get details on an Album by MediaId."""
+        pass
+
+    @abstractmethod
     def album_tracks(self, album_id: MediaId) -> list[Track]:
         """Get details on all Tracks for al Album on the Media Server."""
         pass
@@ -183,13 +188,15 @@ class MediaServer(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def album(self, album_id: MediaId) -> Album:
-        """Get details on an Album by MediaId."""
+    def track(self, track_id: MediaId) -> Track:
+        """Get details on a Track by MediaId."""
         pass
 
     @abstractmethod
-    def track(self, track_id: MediaId) -> Track:
-        """Get details on a Track by MediaId."""
+    def ids_from_filename(
+        self, filename: str, ids: list[MediaType]
+    ) -> dict[MediaType, MediaId]:
+        """Extract Media Ids from the given filename."""
         pass
 
     # -------------------------------------------------------------------------

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -192,7 +192,6 @@ class Album(BaseModel):
     """An album on a local media server."""
 
     id: str | None
-    parentId: str | None
     title: str | None
     creator: str | None
     date: str | None
@@ -205,7 +204,6 @@ class Artist(BaseModel):
     """An artist on a local media server."""
 
     id: str | None
-    parentId: str | None
     title: str | None
     genre: str | None
     album_art_uri: str | None
@@ -215,7 +213,7 @@ class Track(BaseModel):
     """A track on a local media server."""
 
     id: str | None
-    parentId: str | None
+    albumId: str | None
     title: str | None
     creator: str | None
     date: str | None

--- a/vibin/server/routers/browse.py
+++ b/vibin/server/routers/browse.py
@@ -44,8 +44,8 @@ def path_contents(
 )
 @transform_media_server_urls_if_proxying
 @requires_media
-def browse(parent_id: str) -> MediaBrowseSingleLevel:
-    return get_vibin_instance().browse_media(parent_id)
+def children(parent_id: str) -> MediaBrowseSingleLevel:
+    return get_vibin_instance().media_server.children(parent_id)
 
 
 @browse_router.get(
@@ -53,5 +53,5 @@ def browse(parent_id: str) -> MediaBrowseSingleLevel:
 )
 @transform_media_server_urls_if_proxying
 @requires_media
-def browse(id: str):
+def metadata(id: str):
     return xmltodict.parse(get_vibin_instance().media_server.get_metadata(id))

--- a/vibin/types.py
+++ b/vibin/types.py
@@ -11,6 +11,8 @@ from lxml import etree
 #   then that would likely require a refactoring of many of these types.
 # -----------------------------------------------------------------------------
 
+MediaType = Literal["album", "track", "artist"]
+
 MediaId = str  # Local media server id (Album, Track, Artist)
 
 MediaMetadata = dict  # Local media server metadata


### PR DESCRIPTION
* Hydrate all the media ids from the media server before allowing incoming client connections.
* Remove `parentId` from media models.
* Add `albumId` to `Track` model.
* In `Asset`, keep track of all known Album/Artist/Track media ids.
* Add `ids_from_filename()` to `MediaServer` and `Asset`. This moves the determination of ids-from-filenames to the `MediaServer` implementation rather than the `Streamer` implementation.