### PR TITLE
Replace deprecated distutils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "httpx >= 0.24.1, < 0.25",
     "lxml >= 4.9.2, < 5",
     "lyricsgenius >= 3.0.1, < 4",
+    "packaging >= 24.1",
     "requests >= 2.31.0, < 3",
     "rich >= 13.4.2, < 14",
     "starlette >= 0.27.0, < 0.28",

--- a/vibin/utils.py
+++ b/vibin/utils.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 import dataclasses
-from distutils.version import StrictVersion
 import functools
 import json
 import math
@@ -15,6 +14,7 @@ import threading
 import time
 import zipfile
 
+from packaging.version import Version
 from pydantic import BaseModel
 import requests
 import upnpclient
@@ -499,7 +499,7 @@ def get_ui_install_dir() -> Path | None:
         candidate.replace(f"{UI_APPNAME}-", "") for candidate in candidates
     ]
 
-    candidate_versions.sort(key=StrictVersion, reverse=True)
+    candidate_versions.sort(key=Version, reverse=True)
 
     try:
         return Path(UI_ROOT, f"{UI_APPNAME}-{candidate_versions[0]}")


### PR DESCRIPTION
The `distutils` module was removed from the standard library in Python 3.12. This PR replaces `distutils.version.StrictVersion` with `packaging.version.Version`.

The replacement (`packaging`) works with vibin's supported Python versions, 3.10 and higher.