### PR TITLE
Allow volume control via a StreamMagic streamer

### DIFF
--- a/vibin/amplifiers/__init__.py
+++ b/vibin/amplifiers/__init__.py
@@ -2,6 +2,7 @@ from .amplifier import Amplifier
 
 # Each Amplifier implementation should be imported here.
 from .hegel import Hegel
+from .streammagic import StreamMagic
 
 # Map UPnP device models to Amplifier implementations. This is not required if
 # the UPnP model name is the same as the implementation name.
@@ -12,4 +13,5 @@ model_to_amplifier = {
     "H390": Hegel,
     "H590": Hegel,
     "H600": Hegel,
+    "CXNv2": StreamMagic,
 }

--- a/vibin/amplifiers/amplifier.py
+++ b/vibin/amplifiers/amplifier.py
@@ -100,7 +100,7 @@ class Amplifier(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def actions(self) -> list[AmplifierAction]:
+    def supported_actions(self) -> list[AmplifierAction]:
         """Actions supported by this amplifier."""
         pass
 

--- a/vibin/amplifiers/amplifier.py
+++ b/vibin/amplifiers/amplifier.py
@@ -9,7 +9,13 @@ from vibin.models import (
     AudioSources,
     UPnPServiceSubscriptions,
 )
-from vibin.types import MuteState, PowerState, UpdateMessageHandler, UPnPProperties
+from vibin.types import (
+    MuteState,
+    PowerState,
+    UpdateMessageHandler,
+    UPnPProperties,
+    AmplifierAction,
+)
 
 
 # -----------------------------------------------------------------------------
@@ -21,6 +27,7 @@ from vibin.types import MuteState, PowerState, UpdateMessageHandler, UPnPPropert
 # it is likely a very leaky abstraction exposing many design choices of the
 # Hegel server product.
 # -----------------------------------------------------------------------------
+
 
 class Amplifier(metaclass=ABCMeta):
     """
@@ -93,76 +100,82 @@ class Amplifier(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def power(self) -> PowerState:
-        """Power state."""
+    def actions(self) -> list[AmplifierAction]:
+        """Actions supported by this amplifier."""
+        pass
+
+    @property
+    @abstractmethod
+    def power(self) -> PowerState | None:
+        """Power state, if known."""
         pass
 
     @power.setter
     @abstractmethod
     def power(self, state: PowerState) -> None:
-        """Set the power state."""
+        """Set the power state. No-op if not supported."""
         pass
 
     @abstractmethod
     def power_toggle(self) -> None:
-        """Toggle the power state."""
+        """Toggle the power state. No-op if not supported."""
         pass
 
     @property
     @abstractmethod
-    def volume(self) -> float:
-        """Current volume (0-1)."""
+    def volume(self) -> float | None:
+        """Current volume (0-1), if known."""
         pass
 
     @volume.setter
     @abstractmethod
     def volume(self, volume: float) -> None:
-        """Set the volume (0-1)."""
+        """Set the volume (0-1). No-op if not supported."""
         pass
 
     @abstractmethod
     def volume_up(self) -> None:
-        """Increase the volume by one unit."""
+        """Increase the volume by one unit. No-op if not supported."""
         pass
 
     @abstractmethod
     def volume_down(self) -> None:
-        """Decrease the volume by one unit."""
+        """Decrease the volume by one unit. No-op if not supported."""
         pass
 
     @property
     @abstractmethod
-    def mute(self) -> MuteState:
-        """Mute state."""
+    def mute(self) -> MuteState | None:
+        """Mute state, if known."""
         pass
 
     @mute.setter
     @abstractmethod
     def mute(self, state: MuteState) -> None:
-        """Set the mute state."""
+        """Set the mute state. No-op if not supported."""
         pass
 
     @abstractmethod
     def mute_toggle(self) -> None:
-        """Toggle the mute state."""
+        """Toggle the mute state. No-op if not supported."""
         pass
 
     @property
     @abstractmethod
     def audio_sources(self) -> AudioSources | None:
-        """Get the Audio Sources."""
+        """Get the Audio Sources, if any."""
         pass
 
     @property
     @abstractmethod
     def audio_source(self) -> AudioSource | None:
-        """Get the active Audio Source."""
+        """Get the active Audio Source, if known."""
         pass
 
     @audio_source.setter
     @abstractmethod
     def audio_source(self, source: str) -> None:
-        """Set the active Audio Source by name."""
+        """Set the active Audio Source by name. No-op if not supported."""
         pass
 
     # -------------------------------------------------------------------------

--- a/vibin/amplifiers/hegel.py
+++ b/vibin/amplifiers/hegel.py
@@ -129,7 +129,7 @@ class Hegel(Amplifier):
     def device_state(self) -> AmplifierState:
         return AmplifierState(
             name=self._device.friendly_name,
-            actions=self.actions,
+            supported_actions=self.supported_actions,
             power=self.power,
             mute=self.mute,
             volume=self.volume,
@@ -162,7 +162,7 @@ class Hegel(Amplifier):
     # send commands to the amplifier to set the new value.
 
     @property
-    def actions(self) -> list[AmplifierAction]:
+    def supported_actions(self) -> list[AmplifierAction]:
         return ["power", "volume", "mute", "volume_up_down", "audio_source"]
 
     @property

--- a/vibin/amplifiers/hegel.py
+++ b/vibin/amplifiers/hegel.py
@@ -17,8 +17,13 @@ from vibin.models import (
     AudioSources,
     UPnPServiceSubscriptions,
 )
-from vibin.types import MuteState, PowerState, UpdateMessageHandler, UPnPProperties
-
+from vibin.types import (
+    AmplifierAction,
+    MuteState,
+    PowerState,
+    UpdateMessageHandler,
+    UPnPProperties,
+)
 
 # -----------------------------------------------------------------------------
 # Implementation of Amplifier for Hegel amplifiers.
@@ -124,6 +129,7 @@ class Hegel(Amplifier):
     def device_state(self) -> AmplifierState:
         return AmplifierState(
             name=self._device.friendly_name,
+            actions=self.actions,
             power=self.power,
             mute=self.mute,
             volume=self.volume,
@@ -154,6 +160,10 @@ class Hegel(Amplifier):
     # The getters just return the current values from local amplifier state
     # (transforming the value if required; e.g. a "1" to "on"). The setters
     # send commands to the amplifier to set the new value.
+
+    @property
+    def actions(self) -> list[AmplifierAction]:
+        return ["power", "volume", "mute", "volume_up_down", "audio_source"]
 
     @property
     def power(self) -> PowerState:

--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -113,8 +113,8 @@ class StreamMagic(Amplifier):
     # System
 
     @property
-    def actions(self) -> list[AmplifierAction]:
-        return self.device_state.actions
+    def supported_actions(self) -> list[AmplifierAction]:
+        return self.device_state.supported_actions
 
     @property
     def power(self) -> PowerState | None:
@@ -143,19 +143,19 @@ class StreamMagic(Amplifier):
     @volume.setter
     def volume(self, volume: float) -> None:
         """Set the volume (0-1)."""
-        if "volume" in self.device_state.actions and self._max_volume_step:
+        if "volume" in self.device_state.supported_actions and self._max_volume_step:
             self._send_state_request(
                 "volume_step", str(round(volume * self._max_volume_step))
             )
 
     def volume_up(self) -> None:
         """Increase the volume by one unit."""
-        if "volume_up_down" in self.device_state.actions:
+        if "volume_up_down" in self.device_state.supported_actions:
             self._send_state_request("volume_step_change", "1")
 
     def volume_down(self) -> None:
         """Decrease the volume by one unit."""
-        if "volume_up_down" in self.device_state.actions:
+        if "volume_up_down" in self.device_state.supported_actions:
             self._send_state_request("volume_step_change", "-1")
 
     @property
@@ -166,12 +166,12 @@ class StreamMagic(Amplifier):
     @mute.setter
     def mute(self, state: MuteState) -> None:
         """Set the mute state."""
-        if "mute" in self.device_state.actions:
+        if "mute" in self.device_state.supported_actions:
             self._send_state_request("mute", "true" if state == "on" else "false")
 
     def mute_toggle(self) -> None:
         """Toggle the mute state."""
-        if "mute" in self.device_state.actions:
+        if "mute" in self.device_state.supported_actions:
             self._send_state_request(
                 "mute", "false" if self.device_state.mute == "on" else "true"
             )
@@ -252,7 +252,7 @@ class StreamMagic(Amplifier):
         if self._state_data and self._state_data["pre_amp_mode"]:
             return AmplifierState(
                 name=self._device.friendly_name,
-                actions=["volume", "mute", "volume_up_down"],
+                supported_actions=["volume", "mute", "volume_up_down"],
                 power="on" if self._state_data["power"] else "off",
                 mute="on" if self._state_data["mute"] else "off",
                 volume=(
@@ -265,7 +265,7 @@ class StreamMagic(Amplifier):
         elif self._state_data and self._state_data["cbus"] in ["amplifier", "receiver"]:
             return AmplifierState(
                 name=self._device.friendly_name,
-                actions=["volume_up_down"],
+                supported_actions=["volume_up_down"],
                 power="on" if self._state_data["power"] else "off",
                 mute=None,
                 volume=None,
@@ -274,7 +274,7 @@ class StreamMagic(Amplifier):
         elif self._state_data:
             return AmplifierState(
                 name=self._device.friendly_name,
-                actions=[],
+                supported_actions=[],
                 power="on" if self._state_data["power"] else "off",
                 mute=None,
                 volume=None,
@@ -283,7 +283,7 @@ class StreamMagic(Amplifier):
         else:
             return AmplifierState(
                 name=self._device.friendly_name,
-                actions=[],
+                supported_actions=[],
                 power=None,
                 mute=None,
                 volume=None,

--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -61,20 +61,14 @@ class StreamMagic(Amplifier):
         self._on_update = on_update
 
         self._device_hostname = urlparse(device.location).hostname
-        self._device_state = AmplifierState(
-            name=self._device.friendly_name,
-            actions=[],
-            power=None,
-            mute=None,
-            volume=None,
-            sources=None,
-        )
+        self._state_data = None
+        self._max_volume_step = None
 
         self._websocket_thread = WebsocketThread(
             uri=f"ws://{self._device_hostname}:80/smoip",
             friendly_name=self._device.friendly_name,
             on_connect=self._initialize_websocket,
-            on_data=self._handle_state_message,
+            on_data=self._handle_websocket_message,
             on_disconnect=self._on_disconnect,
         )
         self._websocket_thread.start()
@@ -97,7 +91,7 @@ class StreamMagic(Amplifier):
     @property
     def device_state(self) -> AmplifierState:
         """System state for the Amplifier."""
-        return self._device_state
+        return self._compute_amplifier_state()
 
     @property
     def device_udn(self) -> str:
@@ -120,12 +114,12 @@ class StreamMagic(Amplifier):
 
     @property
     def actions(self) -> list[AmplifierAction]:
-        return self._device_state.actions
+        return self.device_state.actions
 
     @property
     def power(self) -> PowerState | None:
         """Power state."""
-        return self._device_state.power
+        return self.device_state.power
 
     @power.setter
     def power(self, state: PowerState) -> None:
@@ -144,46 +138,48 @@ class StreamMagic(Amplifier):
     @property
     def volume(self) -> float | None:
         """Current volume (0-1)."""
-        return self._device_state.volume
+        return self.device_state.volume
 
     @volume.setter
     def volume(self, volume: float) -> None:
         """Set the volume (0-1)."""
-        if "volume" in self._device_state.actions:
-            self._send_state_request("volume_percent", str(round(volume * 100)))
+        if "volume" in self.device_state.actions and self._max_volume_step:
+            self._send_state_request(
+                "volume_step", str(round(volume * self._max_volume_step))
+            )
 
     def volume_up(self) -> None:
         """Increase the volume by one unit."""
-        if "volume_up_down" in self._device_state.actions:
+        if "volume_up_down" in self.device_state.actions:
             self._send_state_request("volume_step_change", "1")
 
     def volume_down(self) -> None:
         """Decrease the volume by one unit."""
-        if "volume_up_down" in self._device_state.actions:
+        if "volume_up_down" in self.device_state.actions:
             self._send_state_request("volume_step_change", "-1")
 
     @property
     def mute(self) -> MuteState | None:
         """Mute state."""
-        return self._device_state.mute
+        return self.device_state.mute
 
     @mute.setter
     def mute(self, state: MuteState) -> None:
         """Set the mute state."""
-        if "mute" in self._device_state.actions:
+        if "mute" in self.device_state.actions:
             self._send_state_request("mute", "true" if state == "on" else "false")
 
     def mute_toggle(self) -> None:
         """Toggle the mute state."""
-        if "mute" in self._device_state.actions:
+        if "mute" in self.device_state.actions:
             self._send_state_request(
-                "mute", "false" if self._device_state.mute == "on" else "true"
+                "mute", "false" if self.device_state.mute == "on" else "true"
             )
 
     @property
     def audio_sources(self) -> AudioSources | None:
         """Not supported."""
-        return self._device_state.sources
+        return self.device_state.sources
 
     @property
     def audio_source(self) -> AudioSource | None:
@@ -216,54 +212,83 @@ class StreamMagic(Amplifier):
 
     async def _initialize_websocket(self, websocket: WebSocketClientProtocol):
         """On connection to the WebSocket, subscribe to StreamMagic events."""
+        await websocket.send('{ "path": "/zone/state/spec", "params": { "update": 1 }}')
         await websocket.send('{ "path": "/zone/state", "params": { "update": 1 }}')
         if self._on_connect:
             self._on_connect()
 
-    def _handle_state_message(self, message: Data):
+    def _handle_websocket_message(self, message: Data):
         try:
             parsed = json.loads(message)
-        except (KeyError, json.decoder.JSONDecodeError):
+        except json.decoder.JSONDecodeError:
             return
 
-        if parsed["path"] != "/zone/state" or parsed["type"] != "update":
+        if "path" not in parsed:
             pass
 
-        data = parsed["params"]["data"]
+        match parsed["path"]:
+            case "/zone/state":
+                self._state_data = parsed["params"]["data"]
+                self._on_update("System", self.device_state)
+            case "/zone/state/spec":
+                try:
+                    # volume_step is only present in pre-amp mode
+                    self._max_volume_step = parsed["params"]["data"]["volume_step"][
+                        "maximum"
+                    ]
+                    self._on_update("System", self.device_state)
+                except KeyError:
+                    pass
+            case _:
+                pass
 
-        # Convert the update message to an AmplifierState.
-        # Report the current power status, so that the Vibin UI can grey out
-        # controls if the streamer isn't currently available, even though this
-        # implementation doesn't support controlling the power.
-        if data["pre_amp_mode"]:
-            self._device_state = AmplifierState(
+    def _compute_amplifier_state(self) -> AmplifierState:
+        """Converts the state messages to an AmplifierState.
+
+        Reports the current power status, so that the Vibin UI can grey out
+        controls if the streamer isn't currently available, even though this
+        implementation doesn't support controlling the power.
+        """
+        if self._state_data and self._state_data["pre_amp_mode"]:
+            return AmplifierState(
                 name=self._device.friendly_name,
                 actions=["volume", "mute", "volume_up_down"],
-                power="on" if data["power"] else "off",
-                mute="on" if data["mute"] else "off",
-                volume=data["volume_percent"] / 100,
+                power="on" if self._state_data["power"] else "off",
+                mute="on" if self._state_data["mute"] else "off",
+                volume=(
+                    self._state_data["volume_step"] / self._max_volume_step
+                    if self._max_volume_step
+                    else None
+                ),
                 sources=None,
             )
-        elif data["cbus"] in ["amplifier", "receiver"]:
-            self._device_state = AmplifierState(
+        elif self._state_data and self._state_data["cbus"] in ["amplifier", "receiver"]:
+            return AmplifierState(
                 name=self._device.friendly_name,
                 actions=["volume_up_down"],
-                power="on" if data["power"] else "off",
+                power="on" if self._state_data["power"] else "off",
+                mute=None,
+                volume=None,
+                sources=None,
+            )
+        elif self._state_data:
+            return AmplifierState(
+                name=self._device.friendly_name,
+                actions=[],
+                power="on" if self._state_data["power"] else "off",
                 mute=None,
                 volume=None,
                 sources=None,
             )
         else:
-            self._device_state = AmplifierState(
+            return AmplifierState(
                 name=self._device.friendly_name,
                 actions=[],
-                power="on" if data["power"] else "off",
+                power=None,
                 mute=None,
                 volume=None,
                 sources=None,
             )
-
-        self._on_update("System", self._device_state)
 
     def _send_state_request(self, param: str, value: str):
         requests.get(f"http://{self._device_hostname}/smoip/zone/state?{param}={value}")

--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -224,7 +224,7 @@ class StreamMagic(Amplifier):
             return
 
         if "path" not in parsed:
-            pass
+            return
 
         match parsed["path"]:
             case "/zone/state":

--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -1,0 +1,269 @@
+import json
+from typing import Callable
+from urllib.parse import urlparse
+
+import requests
+import upnpclient
+from websockets.legacy.client import WebSocketClientProtocol
+from websockets.typing import Data
+
+from vibin.amplifiers import Amplifier
+from vibin.logger import logger
+from vibin.models import (
+    AmplifierState,
+    AudioSources,
+    AudioSource,
+    UPnPServiceSubscriptions,
+)
+from vibin.types import (
+    PowerState,
+    MuteState,
+    UpdateMessageHandler,
+    UPnPProperties,
+    AmplifierAction,
+)
+from vibin.utils import WebsocketThread
+
+
+class StreamMagic(Amplifier):
+    """
+    Control volume via a StreamMagic streamer, such as the CXNv2.
+
+    When a Cambridge Audio amplifier or receiver is connected via the Control
+    Bus, the streamer can send signals to nudge the volume up or down. It
+    can't set the volume to a specific level or report back on the current
+    volume level. Additionally, the amp is automatically switched on and off
+    along with the streamer.
+
+    Alternatively, the streamer can be configured to act as a digital pre-amp,
+    in which case it has full control over the volume level for the signal it
+    sends to the power amp.
+
+    If the streamer is neither configured to use the Control Bus, nor set in
+    pre-amp mode, then no volume control options are available.
+
+    See https://www.cambridgeaudio.com/row/en/blog/getting-most-your-cxn-v2-pt2-volume-control
+    """
+
+    model_name = "StreamMagic"
+
+    def __init__(
+        self,
+        device: upnpclient.Device,
+        upnp_subscription_callback_base: str | None = None,
+        on_connect: Callable[[], None] | None = None,
+        on_disconnect: Callable[[], None] | None = None,
+        on_update: UpdateMessageHandler | None = None,
+    ):
+        self._device = device
+        self._on_connect = on_connect
+        self._on_disconnect = on_disconnect
+        self._on_update = on_update
+
+        self._device_hostname = urlparse(device.location).hostname
+        self._device_state = AmplifierState(
+            name=self._device.friendly_name,
+            actions=[],
+            power=None,
+            mute=None,
+            volume=None,
+            sources=None,
+        )
+
+        self._websocket_thread = WebsocketThread(
+            uri=f"ws://{self._device_hostname}:80/smoip",
+            friendly_name=self._device.friendly_name,
+            on_connect=self._initialize_websocket,
+            on_data=self._handle_state_message,
+            on_disconnect=self._on_disconnect,
+        )
+        self._websocket_thread.start()
+
+    @property
+    def name(self) -> str:
+        """The UPnP device name for the Amplifier."""
+        return self._device.friendly_name
+
+    @property
+    def connected(self) -> bool:
+        """Whether an active connection has been established."""
+        return self._websocket_thread.connected()
+
+    @property
+    def device(self) -> upnpclient.Device:
+        """The UPnP device instance associated with the Amplifier."""
+        return self._device
+
+    @property
+    def device_state(self) -> AmplifierState:
+        """System state for the Amplifier."""
+        return self._device_state
+
+    @property
+    def device_udn(self) -> str:
+        """The Amplifier's UPnP device UDN (Unique Device Name)."""
+        return self._device.udn.removeprefix("uuid:")
+
+    def on_startup(self) -> None:
+        """Called when the Vibin system has started up."""
+        pass
+
+    def on_shutdown(self) -> None:
+        """Called when the Vibin system is shut down."""
+        logger.info(f"Stopping WebSocket thread for {self.name}")
+        if self._websocket_thread:
+            self._websocket_thread.stop()
+            self._websocket_thread.join()
+
+    # -------------------------------------------------------------------------
+    # System
+
+    @property
+    def actions(self) -> list[AmplifierAction]:
+        return self._device_state.actions
+
+    @property
+    def power(self) -> PowerState | None:
+        """Power state."""
+        return self._device_state.power
+
+    @power.setter
+    def power(self, state: PowerState) -> None:
+        """Not supported.
+
+        We could control the power state of the streamer by sending
+        `power=true` or `power=false`. But that should be performed via the
+        `Streamer` implementation instead.
+        """
+        pass
+
+    def power_toggle(self) -> None:
+        """Not supported."""
+        pass
+
+    @property
+    def volume(self) -> float | None:
+        """Current volume (0-1)."""
+        return self._device_state.volume
+
+    @volume.setter
+    def volume(self, volume: float) -> None:
+        """Set the volume (0-1)."""
+        if "volume" in self._device_state.actions:
+            self._send_state_request("volume_percent", str(round(volume * 100)))
+
+    def volume_up(self) -> None:
+        """Increase the volume by one unit."""
+        if "volume_up_down" in self._device_state.actions:
+            self._send_state_request("volume_step_change", "1")
+
+    def volume_down(self) -> None:
+        """Decrease the volume by one unit."""
+        if "volume_up_down" in self._device_state.actions:
+            self._send_state_request("volume_step_change", "-1")
+
+    @property
+    def mute(self) -> MuteState | None:
+        """Mute state."""
+        return self._device_state.mute
+
+    @mute.setter
+    def mute(self, state: MuteState) -> None:
+        """Set the mute state."""
+        if "mute" in self._device_state.actions:
+            self._send_state_request("mute", "true" if state == "on" else "false")
+
+    def mute_toggle(self) -> None:
+        """Toggle the mute state."""
+        if "mute" in self._device_state.actions:
+            self._send_state_request(
+                "mute", "false" if self._device_state.mute == "on" else "true"
+            )
+
+    @property
+    def audio_sources(self) -> AudioSources | None:
+        """Not supported."""
+        return self._device_state.sources
+
+    @property
+    def audio_source(self) -> AudioSource | None:
+        """Not supported."""
+        return None
+
+    @audio_source.setter
+    def audio_source(self, source: str) -> None:
+        """Not supported."""
+        pass
+
+    # -------------------------------------------------------------------------
+    # UPnP
+
+    def subscribe_to_upnp_events(self) -> None:
+        return None
+
+    def upnp_properties(self) -> UPnPProperties:
+        return {}
+
+    @property
+    def upnp_subscriptions(self) -> UPnPServiceSubscriptions:
+        return {}
+
+    def on_upnp_event(self, service_name: str, event: str):
+        return None
+
+    # -------------------------------------------------------------------------
+    # SMOIP
+
+    async def _initialize_websocket(self, websocket: WebSocketClientProtocol):
+        """On connection to the WebSocket, subscribe to StreamMagic events."""
+        await websocket.send('{ "path": "/zone/state", "params": { "update": 1 }}')
+        if self._on_connect:
+            self._on_connect()
+
+    def _handle_state_message(self, message: Data):
+        try:
+            parsed = json.loads(message)
+        except (KeyError, json.decoder.JSONDecodeError):
+            return
+
+        if parsed["path"] != "/zone/state" or parsed["type"] != "update":
+            pass
+
+        data = parsed["params"]["data"]
+
+        # Convert the update message to an AmplifierState.
+        # Report the current power status, so that the Vibin UI can grey out
+        # controls if the streamer isn't currently available, even though this
+        # implementation doesn't support controlling the power.
+        if data["pre_amp_mode"]:
+            self._device_state = AmplifierState(
+                name=self._device.friendly_name,
+                actions=["volume", "mute", "volume_up_down"],
+                power="on" if data["power"] else "off",
+                mute="on" if data["mute"] else "off",
+                volume=data["volume_percent"] / 100,
+                sources=None,
+            )
+        elif data["cbus"] in ["amplifier", "receiver"]:
+            self._device_state = AmplifierState(
+                name=self._device.friendly_name,
+                actions=["volume_up_down"],
+                power="on" if data["power"] else "off",
+                mute=None,
+                volume=None,
+                sources=None,
+            )
+        else:
+            self._device_state = AmplifierState(
+                name=self._device.friendly_name,
+                actions=[],
+                power="on" if data["power"] else "off",
+                mute=None,
+                volume=None,
+                sources=None,
+            )
+
+        self._on_update("System", self._device_state)
+
+    def _send_state_request(self, param: str, value: str):
+        requests.get(f"http://{self._device_hostname}/smoip/zone/state?{param}={value}")

--- a/vibin/base.py
+++ b/vibin/base.py
@@ -309,9 +309,8 @@ class Vibin:
         """
         system_power = "off" if self.streamer.power is None else self.streamer.power
 
-        if self.amplifier is not None:
-            if self.amplifier.power == "off" or self.amplifier.power is None:
-                system_power = "off"
+        if self.amplifier and self.amplifier.power == "off":
+            system_power = "off"
 
         return SystemState(
             power=system_power,

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 import upnpclient
 
 from vibin.types import (
+    AmplifierAction,
     FavoriteType,
     MediaId,
     MuteState,
@@ -140,6 +141,7 @@ class MediaServerState(UPnPDeviceState):
 class AmplifierState(UPnPDeviceState):
     """Amplifier hardware state."""
 
+    actions: list[AmplifierAction]
     power: PowerState | None
     mute: MuteState | None
     volume: float | None

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -141,7 +141,7 @@ class MediaServerState(UPnPDeviceState):
 class AmplifierState(UPnPDeviceState):
     """Amplifier hardware state."""
 
-    actions: list[AmplifierAction]
+    supported_actions: list[AmplifierAction]
     power: PowerState | None
     mute: MuteState | None
     volume: float | None

--- a/vibin/server/dependencies.py
+++ b/vibin/server/dependencies.py
@@ -169,7 +169,7 @@ def requires_amplifier(actions: list[AmplifierAction]=None, allow_if_off=False):
                 )
 
             for action in actions or []:
-                if action not in _vibin.amplifier.actions:
+                if action not in _vibin.amplifier.supported_actions:
                     raise HTTPException(
                         status_code=404,
                         detail="Feature unavailable (amplifier doesn't support action)",

--- a/vibin/server/routers/system.py
+++ b/vibin/server/routers/system.py
@@ -188,7 +188,7 @@ def amplifier_power() -> AmplifierState:
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier(allow_if_off=True)
+@requires_amplifier(actions=["power"], allow_if_off=True)
 def amplifier_power_on():
     try:
         get_vibin_instance().amplifier.power = "on"
@@ -201,7 +201,7 @@ def amplifier_power_on():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["power"])
 def amplifier_power_off():
     try:
         get_vibin_instance().amplifier.power = "off"
@@ -215,7 +215,7 @@ def amplifier_power_off():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier(allow_if_off=True)
+@requires_amplifier(actions=["power"], allow_if_off=True)
 def amplifier_power_toggle():
     try:
         get_vibin_instance().amplifier.power_toggle()
@@ -228,7 +228,7 @@ def amplifier_power_toggle():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["volume_up_down"])
 def amplifier_volume_up():
     try:
         get_vibin_instance().amplifier.volume_up()
@@ -242,7 +242,7 @@ def amplifier_volume_up():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["volume_up_down"])
 def amplifier_volume_down():
     try:
         get_vibin_instance().amplifier.volume_down()
@@ -256,7 +256,7 @@ def amplifier_volume_down():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["volume"])
 def amplifier_volume_set(volume: Annotated[float, Path(ge=0.0, le=1.0)]):
     try:
         get_vibin_instance().amplifier.volume = volume
@@ -270,7 +270,7 @@ def amplifier_volume_set(volume: Annotated[float, Path(ge=0.0, le=1.0)]):
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["mute"])
 def amplifier_mute_on():
     try:
         get_vibin_instance().amplifier.mute = "on"
@@ -284,7 +284,7 @@ def amplifier_mute_on():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["mute"])
 def amplifier_mute_off():
     try:
         get_vibin_instance().amplifier.mute = "off"
@@ -298,7 +298,7 @@ def amplifier_mute_off():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["mute"])
 def amplifier_mute_toggle():
     try:
         get_vibin_instance().amplifier.mute_toggle()
@@ -312,7 +312,7 @@ def amplifier_mute_toggle():
     tags=["Media System"],
     response_class=Response,
 )
-@requires_amplifier()
+@requires_amplifier(actions=["audio_source"])
 def amplifier_set_audio_source(source_name: Any):
     try:
         get_vibin_instance().amplifier.audio_source = str(source_name)

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -8,7 +8,7 @@ import pathlib
 import queue
 import re
 import sys
-from typing import Literal
+from typing import Literal, Any
 from urllib.parse import urlparse
 import uuid
 import xml.etree.ElementTree as ET
@@ -1067,10 +1067,14 @@ class StreamMagic(Streamer):
     def _process_streamer_message(self, update: Data) -> None:
         """Process a single incoming message from the StreamMagic WebSocket server."""
         try:
-            update_dict = json.loads(update)
+            self._process_update_message(json.loads(update))
         except (KeyError, json.decoder.JSONDecodeError):
-            return
+            # TODO: This currently quietly ignores unexpected payload formats
+            #   or missing keys. Consider adding error handling if errors need
+            #   to be announced.
+            pass
 
+    def _process_update_message(self, update_dict: dict[str, Any]):
         if update_dict["path"] == "/zone/play_state":
             # Current play state ----------------------------------------------
             play_state = update_dict["params"]["data"]

--- a/vibin/streamers/streammagic.py
+++ b/vibin/streamers/streammagic.py
@@ -1,5 +1,4 @@
 import array
-import asyncio
 import atexit
 import base64
 import functools
@@ -20,7 +19,8 @@ import requests
 import untangle
 import upnpclient
 from upnpclient.marshal import marshal_value
-import websockets
+from websockets.legacy.client import WebSocketClientProtocol
+from websockets.typing import Data
 import xmltodict
 
 from vibin import (
@@ -63,7 +63,7 @@ from vibin.types import (
     UPnPPropertyChangeHandlers,
 )
 from vibin.streamers import Streamer
-from vibin.utils import UPnPSubscriptionManagerThread
+from vibin.utils import UPnPSubscriptionManagerThread, WebsocketThread
 
 
 # See Streamer interface for method documentation.
@@ -143,7 +143,6 @@ class StreamMagic(Streamer):
         self._media_server: MediaServer | None = None
         self._instance_id = 0  # StreamMagic implements a static AVTransport instance
         self._websocket_thread = None
-        self._websocket_timeout = 1
 
         self._uu_vol_control = device.UuVolControl
         self._av_transport = device.AVTransport
@@ -225,8 +224,11 @@ class StreamMagic(Streamer):
             pass
 
         if self._on_update:
-            self._websocket_thread = utils.StoppableThread(
-                target=self._handle_websocket_to_streamer
+            self._websocket_thread = WebsocketThread(
+                uri=f"ws://{self._device_hostname}:80/smoip",
+                friendly_name=self._device.friendly_name,
+                on_connect=self._initialize_websocket,
+                on_data=self._process_streamer_message,
             )
             self._websocket_thread.start()
 
@@ -1042,101 +1044,33 @@ class StreamMagic(Streamer):
     # WebSocket connection to StreamMagic streamer.
     # =========================================================================
 
-    def _handle_websocket_to_streamer(self):
-        """Handle the WebSocket connection to the StreamMagic WebSocket server.
+    async def _initialize_websocket(self, websocket: WebSocketClientProtocol):
+        # Request playhead position updates (these arrive one per sec).
+        await websocket.send(
+            '{"path": "/zone/play_state/position", "params": {"update": 1}}'
+        )
 
-        On connection, subscribe to a variety of StreamMagic events. Then
-        continue to process messages as they come in, until told to stop
-        (probably because the system is shutting down).
-        """
-        async def async_websocket_manager():
-            uri = f"ws://{self._device_hostname}:80/smoip"
-            logger.info(f"Connecting to {self.name} WebSocket server on {uri}")
+        # Request now-playing updates, so the "controls" information can
+        # be used to track active transport controls for TransportState
+        # messages.
+        await websocket.send('{"path": "/zone/now_playing", "params": {"update": 1}}')
 
-            wait_for_message = True
+        # Request play state updates (these arrive one per track change).
+        await websocket.send('{"path": "/zone/play_state", "params": {"update": 1}}')
 
-            # TODO: Handle condition where the uri is technically valid, but the
-            #   connection cannot be established.
+        # Request preset updates.
+        await websocket.send('{"path": "/presets/list", "params": {"update": 1}}')
 
-            try:
-                # The "for" iteration automatically takes care of reconnects.
-                async for websocket in websockets.connect(
-                    uri,
-                    ssl=None,
-                    extra_headers={
-                        "Origin": "vibin",
-                    },
-                ):
-                    try:
-                        logger.info(f"Successfully connected to {self.name} WebSocket server")
+        # Request power updates (on/off).
+        await websocket.send('{"path": "/system/power", "params": {"update": 100}}')
 
-                        # Request playhead position updates (these arrive one per sec).
-                        await websocket.send(
-                            '{"path": "/zone/play_state/position", "params": {"update": 1}}'
-                        )
-
-                        # Request now-playing updates, so the "controls" information can
-                        # be used to track active transport controls for TransportState
-                        # messages.
-                        await websocket.send(
-                            '{"path": "/zone/now_playing", "params": {"update": 1}}'
-                        )
-
-                        # Request play state updates (these arrive one per track change).
-                        await websocket.send(
-                            '{"path": "/zone/play_state", "params": {"update": 1}}'
-                        )
-
-                        # Request preset updates.
-                        await websocket.send(
-                            '{"path": "/presets/list", "params": {"update": 1}}'
-                        )
-
-                        # Request power updates (on/off).
-                        await websocket.send(
-                            '{"path": "/system/power", "params": {"update": 100}}'
-                        )
-
-                        while wait_for_message:
-                            try:
-                                # Wait for an incoming message
-                                update = await asyncio.wait_for(
-                                    websocket.recv(), timeout=self._websocket_timeout
-                                )
-                            except asyncio.TimeoutError:
-                                if not self._websocket_thread.stop_event.is_set():
-                                    # Keep listening for incoming messages
-                                    continue
-
-                                # The thread we're running in has been told to stop
-                                wait_for_message = False
-
-                            try:
-                                self._process_streamer_message(json.loads(update))
-                            except (KeyError, json.decoder.JSONDecodeError) as e:
-                                # TODO: This currently quietly ignores unexpected
-                                #   payload formats or missing keys. Consider adding
-                                #   error handling if errors need to be announced.
-                                pass
-
-                        logger.info(f"WebSocket connection to {self.name} closed by Vibin")
-                        return
-                    except websockets.ConnectionClosed:
-                        # Attempt a re-connect when the streamer drops the connection
-                        logger.warning(
-                            f"Lost connection to {self.name} WebSocket server; " +
-                            "attempting reconnect"
-                        )
-
-                        # Continue the "for" loop, which will trigger a reconnect.
-                        continue
-            except websockets.WebSocketException as e:
-                logger.error(f"WebSocket error from {self.name}: {e}")
-
-        asyncio.run(async_websocket_manager())
-
-    def _process_streamer_message(self, update_dict: dict) -> None:
+    def _process_streamer_message(self, update: Data) -> None:
         """Process a single incoming message from the StreamMagic WebSocket server."""
+        try:
+            update_dict = json.loads(update)
+        except (KeyError, json.decoder.JSONDecodeError):
+            return
+
         if update_dict["path"] == "/zone/play_state":
             # Current play state ----------------------------------------------
             play_state = update_dict["params"]["data"]

--- a/vibin/types.py
+++ b/vibin/types.py
@@ -117,3 +117,14 @@ DatabaseName = Literal[
     "playlists",
     "settings",
 ]
+
+# Amplifier -------------------------------------------------------------------
+
+# Actions that can be performed by an amplifier
+AmplifierAction = Literal[
+    "power",
+    "volume",
+    "mute",
+    "volume_up_down",
+    "audio_source",
+]


### PR DESCRIPTION
Allows volume control via a StreamMagic streamer. Not enabled by default - the streamer's friendly name should be set with the `--amplifier` flag.

StreamMagic streamers - at least, the CXNv2 - support two different modes of controlling the volume. See https://www.cambridgeaudio.com/row/en/blog/getting-most-your-cxn-v2-pt2-volume-control. In pre-amp mode, the streamer acts as a digital pre-amp, with all the usual volume controls available - the volume is reported back to Vibin, and can be set to a specific value. Muting works, too. Otherwise, if the control bus is enabled, the streamer can control an attached Cambridge Audio amp such as the CXA series. In this case, volume can only be nudged up and down and no current volume level is reported back. If neither pre-amp nor control bus is enabled, no volume controls are available.

To allow the Vibin UI to handle both cases, this adds a list of supported actions to the AmplifierState object.

I'll also make a counterpart pull request for the client.