### PR TITLE
Treat volume as an integer, up to the amplifier's reported maximum

### DIFF
--- a/vibin/amplifiers/amplifier.py
+++ b/vibin/amplifiers/amplifier.py
@@ -123,14 +123,20 @@ class Amplifier(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def volume(self) -> float | None:
-        """Current volume (0-1), if known."""
+    def max_volume(self) -> int | None:
+        """Maximum volume level, if available."""
+        pass
+
+    @property
+    @abstractmethod
+    def volume(self) -> int | None:
+        """Current volume (zero to max_volume), if known."""
         pass
 
     @volume.setter
     @abstractmethod
-    def volume(self, volume: float) -> None:
-        """Set the volume (0-1). No-op if not supported."""
+    def volume(self, volume: int) -> None:
+        """Set the volume (zero to max_volume). No-op if not supported."""
         pass
 
     @abstractmethod

--- a/vibin/amplifiers/hegel.py
+++ b/vibin/amplifiers/hegel.py
@@ -132,6 +132,7 @@ class Hegel(Amplifier):
             supported_actions=self.supported_actions,
             power=self.power,
             mute=self.mute,
+            max_volume=self.max_volume,
             volume=self.volume,
             sources=self.audio_sources,
         )
@@ -187,24 +188,27 @@ class Hegel(Amplifier):
         self._cmd_queue.put_nowait(HegelCommand(name="p", parameter="t"))
 
     @property
-    def volume(self) -> float:
-        """Current volume (0-1)."""
+    def max_volume(self) -> int | None:
+        """Maximum volume level."""
+        return 100
+
+    @property
+    def volume(self) -> int:
+        """Current volume (zero to max_volume)."""
         try:
             vol = self._state["v"]
 
             if vol is None:
                 return 0
 
-            return int(vol) / 100
+            return int(vol)
         except (TypeError, ValueError) as e:
             raise VibinError(f"Could determine normalized Hegel volume: {e}")
 
     @volume.setter
-    def volume(self, volume: float) -> None:
-        """Set the volume (0-1)."""
-        self._cmd_queue.put_nowait(
-            HegelCommand(name="v", parameter=str(int(volume * 100)))
-        )
+    def volume(self, volume: int) -> None:
+        """Set the volume (zero to max_volume)."""
+        self._cmd_queue.put_nowait(HegelCommand(name="v", parameter=str(volume)))
 
     def volume_up(self) -> None:
         """Increase the volume by one unit."""

--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -136,17 +136,20 @@ class StreamMagic(Amplifier):
         pass
 
     @property
+    def max_volume(self) -> int | None:
+        """Maximum volume level, if available."""
+        return self.device_state.max_volume
+
+    @property
     def volume(self) -> float | None:
-        """Current volume (0-1)."""
+        """Current volume (zero to max_volume), if known."""
         return self.device_state.volume
 
     @volume.setter
-    def volume(self, volume: float) -> None:
-        """Set the volume (0-1)."""
-        if "volume" in self.device_state.supported_actions and self._max_volume_step:
-            self._send_state_request(
-                "volume_step", str(round(volume * self._max_volume_step))
-            )
+    def volume(self, volume: int) -> None:
+        """Set the volume (zero to max_volume). No-op if not supported."""
+        if "volume" in self.device_state.supported_actions:
+            self._send_state_request("volume_step", str(volume))
 
     def volume_up(self) -> None:
         """Increase the volume by one unit."""
@@ -255,11 +258,8 @@ class StreamMagic(Amplifier):
                 supported_actions=["volume", "mute", "volume_up_down"],
                 power="on" if self._state_data["power"] else "off",
                 mute="on" if self._state_data["mute"] else "off",
-                volume=(
-                    self._state_data["volume_step"] / self._max_volume_step
-                    if self._max_volume_step
-                    else None
-                ),
+                max_volume=self._max_volume_step,
+                volume=self._state_data["volume_step"],
                 sources=None,
             )
         elif self._state_data and self._state_data["cbus"] in ["amplifier", "receiver"]:
@@ -268,6 +268,7 @@ class StreamMagic(Amplifier):
                 supported_actions=["volume_up_down"],
                 power="on" if self._state_data["power"] else "off",
                 mute=None,
+                max_volume=None,
                 volume=None,
                 sources=None,
             )
@@ -277,6 +278,7 @@ class StreamMagic(Amplifier):
                 supported_actions=[],
                 power="on" if self._state_data["power"] else "off",
                 mute=None,
+                max_volume=None,
                 volume=None,
                 sources=None,
             )
@@ -286,6 +288,7 @@ class StreamMagic(Amplifier):
                 supported_actions=[],
                 power=None,
                 mute=None,
+                max_volume=None,
                 volume=None,
                 sources=None,
             )

--- a/vibin/models.py
+++ b/vibin/models.py
@@ -144,7 +144,8 @@ class AmplifierState(UPnPDeviceState):
     supported_actions: list[AmplifierAction]
     power: PowerState | None
     mute: MuteState | None
-    volume: float | None
+    max_volume: int | None
+    volume: int | None
     sources: AudioSources | None = AudioSources()
 
 

--- a/vibin/server/routers/system.py
+++ b/vibin/server/routers/system.py
@@ -257,8 +257,16 @@ def amplifier_volume_down():
     response_class=Response,
 )
 @requires_amplifier(actions=["volume"])
-def amplifier_volume_set(volume: Annotated[float, Path(ge=0.0, le=1.0)]):
+def amplifier_volume_set(volume: int):
     try:
+        amplifier = get_vibin_instance().amplifier
+
+        if volume < 0:
+            raise HTTPException(status_code=400, detail="Volume out of range")
+
+        if amplifier.max_volume and volume > amplifier.max_volume:
+            raise HTTPException(status_code=400, detail="Volume out of range")
+
         get_vibin_instance().amplifier.volume = volume
     except VibinError as e:
         raise HTTPException(status_code=500, detail=f"{e}")


### PR DESCRIPTION
Presently, vibin reports the volume as a fraction (0-1) which is rendered in the UI as an integer value out of 100.

When the amplifier's native maximum volume isn't 100, this causes some issues when converting values. Mainly, the volume slider can jump after setting it. e.g. for a CXNv2, the maximum volume is 30. So setting the volume to 98 in vibinui would be rounded down to 29, which updates the slider to 97%. There are similar issues when setting the volume with the uparrow/downarrow keys, which expect to be able to set the volume with a granularity of 1%.

This PR adds a new `max_volume` field to `AmplifierState`, and changes the `volume` property to use an integer up to that `max_volume`. I'll raise a matching PR for vibinui which updates the UI to show the integer volume values up to the amplifier-specific max volume.

This makes the volume slider and up/down keypresses much less janky.