### PR TITLE
Use a streamer's natural `Amplifier` implementation if no others found

### DIFF
--- a/vibin/amplifiers/streammagic.py
+++ b/vibin/amplifiers/streammagic.py
@@ -118,8 +118,8 @@ class StreamMagic(Amplifier):
 
     @property
     def power(self) -> PowerState | None:
-        """Power state."""
-        return self.device_state.power
+        """Power state. Not supported."""
+        return None
 
     @power.setter
     def power(self, state: PowerState) -> None:
@@ -256,7 +256,7 @@ class StreamMagic(Amplifier):
             return AmplifierState(
                 name=self._device.friendly_name,
                 supported_actions=["volume", "mute", "volume_up_down"],
-                power="on" if self._state_data["power"] else "off",
+                power=None,
                 mute="on" if self._state_data["mute"] else "off",
                 max_volume=self._max_volume_step,
                 volume=self._state_data["volume_step"],
@@ -266,7 +266,7 @@ class StreamMagic(Amplifier):
             return AmplifierState(
                 name=self._device.friendly_name,
                 supported_actions=["volume_up_down"],
-                power="on" if self._state_data["power"] else "off",
+                power=None,
                 mute=None,
                 max_volume=None,
                 volume=None,
@@ -276,7 +276,7 @@ class StreamMagic(Amplifier):
             return AmplifierState(
                 name=self._device.friendly_name,
                 supported_actions=[],
-                power="on" if self._state_data["power"] else "off",
+                power=None,
                 mute=None,
                 max_volume=None,
                 volume=None,

--- a/vibin/device_resolution.py
+++ b/vibin/device_resolution.py
@@ -311,7 +311,6 @@ def _determine_amplifier_device(
                 device
                 for device in devices
                 if "MediaRenderer" in device.device_type
-                and device != streamer_device
             ]
 
             if len(media_renderers) == 1:


### PR DESCRIPTION
Currently, enabling the Streammagic `Amplifier` implementation requires the `--amplifier` flag to be provided on the command line. I wanted to allow that to happen by default, if no other amplifier is discovered on the network.

If the Streamer isn't configured to support volume controls via either Control Bus or PreAmp mode, this `Amplifier` implementation will be a no-op implementation anyway. The web UI will treat it as if it were absent. So this should be a reasonable default for most users of a Streammagic streamer.

Additionally, this PR contains the server-side fix for mjoblin/vibinui#281, which I thought should be fixed before using the Streammagic `Amplifier` as a default.