### PR TITLE
Fix waveform generation

### DIFF
--- a/vibin/managers/waveform_manager.py
+++ b/vibin/managers/waveform_manager.py
@@ -97,10 +97,13 @@ class WaveformManager:
                     capture_output=True,
                 )
 
-                if waveform_data.stderr:
-                    raise VibinError(
-                        f"Error running audiowaveform tool: {waveform_data.stderr.decode('utf-8')}"
-                    )
+                if waveform_data.returncode != 0:
+                    error_msg = f"[code: {waveform_data.returncode}]"
+
+                    if waveform_data.stderr:
+                        error_msg += f" {waveform_data.stderr.decode('utf-8')}"
+
+                    raise VibinError(f"Error running audiowaveform tool: {error_msg}")
 
                 if data_format == "json":
                     try:


### PR DESCRIPTION
Waveform generation uses the `audiowaveform` tool. This tool writes its progress to stderr, but Vibin was treating a non-empty stderr as an error. This PR instead uses a non-zero `returncode` to determine error states.

Not sure off hand whether this is a regression, or whether the behavior of `audiowaveform` changed.

Fixes #141 